### PR TITLE
Match '.','-','_' in tag sanitization in addition to ' '

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -686,7 +686,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     @SuppressWarnings("static-method")
     protected String sanitizeTag(String tag) {
         // remove spaces and make strong case
-        String[] parts = tag.split(" ");
+        String[] parts = tag.split("[ -._]");
         StringBuilder buf = new StringBuilder();
         for (String part : parts) {
             if (isNotEmpty(part)) {


### PR DESCRIPTION
This allows for these common characters in tags resulting in more properly cased Api class names.

E.g.,
"order-service" => OrderServiceApi instead of OrderserviceApi